### PR TITLE
Fix documentation and configuration issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ Here is the full list of predefined command actions:
 
 ```lua
 require("codegpt").setup({
-  api = {
-    provider = "openai",  -- or "Ollama", "Azure", etc.
+  connection = {
+    api_provider = "openai",  -- or "Ollama", "Azure", etc.
     openai_api_key = vim.fn.getenv("OPENAI_API_KEY"),
     chat_completions_url = "https://api.openai.com/v1/chat/completions",
   },

--- a/lua/codegpt/config.lua
+++ b/lua/codegpt/config.lua
@@ -58,6 +58,7 @@ local default_commands = {
 			cpp = "Use doxygen style comments for functions.",
 			java = "Use JavaDoc style comments for functions.",
 		},
+		callback_type = "prepend_lines",
 	},
 	opt = {
 		user_message_template = "I have the following {{language}} code: ```{{filetype}}\n{{text_selection}}```\nOptimize this code. {{language_instructions}} Only return the code snippet and nothing else.",

--- a/lua/codegpt/config.lua
+++ b/lua/codegpt/config.lua
@@ -133,7 +133,7 @@ M.persistent_override = nil
 
 ---@class codegpt.Connection
 ---@field chat_completions_url? string OpenAI API compatible API endpoint
----@field openai_api_key? string https://platform.openai.com/account/api-keys
+---@field openai_api_key? string | nil Defaults to the value of the `OPENAI_API_KEY` environment variable. Get one here: https://platform.openai.com/account/api-keys
 ---@field ollama_base_url? string ollama base api url default: http://localhost:11434/api/
 ---@field api_provider? codegpt.ProviderType Type of provider for the OpenAI API endpoint
 ---@field proxy? string [protocol://]host[:port] e.g. socks5://127.0.0.1:9999
@@ -167,6 +167,7 @@ M.persistent_override = nil
 local defaults = {
 	connection = {
 		api_provider = "openai",
+                openai_api_key = os.getenv("OPENAI_API_KEY"),
 		chat_completions_url = "https://api.openai.com/v1/chat/completions",
 		ollama_base_url = "http://localhost:11434",
 		proxy = nil,
@@ -233,11 +234,6 @@ M.opts = {}
 ---@param options? codegpt.Options
 M.setup = function(options)
 	M.opts = vim.tbl_deep_extend("force", {}, defaults, options or {})
-
-	-- env takes precedences
-	if vim.fn.getenv("OPENAI_API_KEY") ~= nil then
-		M.opts.connection.openai_api_key = vim.fn.getenv("OPENAI_API_KEY")
-	end
 
 	-- print(vim.inspect(M.opts))
 end


### PR DESCRIPTION
- **Fix callback_type for doc command**: Changed from default `replace_lines` to `prepend_lines` so documentation is added above code instead of replacing it, Because the prompt of the `doc` command tells the AI to generate the document only.
- **Fix incorrect configuration example in README**: Updated setup configuration example to use correct table names ('connection' instead of 'api', 'api_provider' instead of 'provider')                                                                                                              
- **Improve OpenAI API key configuration**: Set default API key from OPENAI_API_KEY environment variable and updated documentation. I think it is more intuitive for the environment to provide the default options and then override them with explicit configuration.